### PR TITLE
fix: Change $not to no longer mutate the filter object and add test to make sure frozen objects don't break the filter evaluation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-json-match",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Lightweight solution to evalute if JSON match desired input",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -636,11 +636,32 @@ describe('matchJsonToSchema.test.ts', () => {
     ],
   ];
 
+  const deepFreeze = (obj: any): any => {
+    const object_keys = Object.keys(obj);
+
+    for (const key of object_keys) {
+      const property_value = obj[key];
+
+      if (
+        typeof property_value === 'object' &&
+        property_value !== null &&
+        !Object.isFrozen(property_value)
+      ) {
+        deepFreeze(property_value);
+      }
+    }
+
+    return Object.freeze(obj);
+  };
+
   tests.forEach(([input, schema, match]) => {
     it(`Correctly matches ${JSON.stringify(input)} with ${JSON.stringify(
       schema
     )} expect ${match}`, async () => {
       expect(matchJsonToSchema(input as any, schema as any)).toBe(match);
+      expect(
+        matchJsonToSchema(deepFreeze(input as any), deepFreeze(schema as any))
+      ).toBe(match);
     });
 
     it(`Correctly matches ${JSON.stringify(input)} with ${JSON.stringify({
@@ -649,6 +670,12 @@ describe('matchJsonToSchema.test.ts', () => {
       expect(matchJsonToSchema(input as any, { $not: schema } as any)).toBe(
         !match
       );
+      expect(
+        matchJsonToSchema(
+          deepFreeze(input as any),
+          deepFreeze({ $not: schema } as any)
+        )
+      ).toBe(!match);
     });
   });
 
@@ -657,6 +684,9 @@ describe('matchJsonToSchema.test.ts', () => {
       schema
     )} expect ${match}`, async () => {
       expect(matchJsonToSchema(input as any, schema as any)).toBe(match);
+      expect(
+        matchJsonToSchema(deepFreeze(input as any), deepFreeze(schema as any))
+      ).toBe(match);
     });
   });
 });


### PR DESCRIPTION
In the previous implementation of $not operator we deleted the operator with `delete schema["$not"]` which it turns out breaks the evaluation if the input filter schema is a frozen javascript object since the `delete` fails silently.

That caused the $not to not apply and incorrect fail the evaluation.

Added tests with frozen input and output objects